### PR TITLE
Fix dockerfile multi-arch build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine as builder
+FROM --platform=${BUILDPLATFORM} golang:1.18-alpine as builder
 
 WORKDIR /workspace
 COPY go.* .
@@ -6,7 +6,9 @@ RUN go mod download
 
 COPY cmd/ cmd/
 COPY internal/ internal/
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+
+ARG TARGETOS TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -a -o manager cmd/main.go
 
 #--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Currently, `GOARCH` is always set to `amd64`. This change uses the `TARGETARCH` build variable.