### PR TITLE
enable a dynamic target lookup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/mabels/ipaddress/go/ipaddress v0.0.0-20211229223036-692af3b12a67 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/go.sum
+++ b/go.sum
@@ -1037,6 +1037,8 @@ github.com/looplab/fsm v0.1.0/go.mod h1:m2VaOfDHxqXBBMgc26m6yUOwkFn8H2AlJDE+jd/u
 github.com/lucas-clemente/quic-go v0.23.0/go.mod h1:paZuzjXCE5mj6sikVLMvqXk8lJV2AsqtJ6bDhjEfxx0=
 github.com/lunixbochs/vtclean v1.0.0/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
+github.com/mabels/ipaddress/go/ipaddress v0.0.0-20211229223036-692af3b12a67 h1:bVDE1M+1x2gmAsV2pdNa/9X4z5K2IitUSfC8L19FkhE=
+github.com/mabels/ipaddress/go/ipaddress v0.0.0-20211229223036-692af3b12a67/go.mod h1:1mdRW3hfT/mDTtpLkQ8y0Ez5WHZvH9wx9YMw9zq9OLQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.4/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=

--- a/internal/controllers/ingressroute.go
+++ b/internal/controllers/ingressroute.go
@@ -27,7 +27,7 @@ type IngressRouteReconciler struct {
 func NewIngressRouteReconciler(
 	client client.Client, logger *zap.Logger, config configv1.Config,
 ) (IngressRouteReconciler, error) {
-	integrations, err := integrationsFromConfig(config, client)
+	integrations, err := integrationsFromConfig(config, client, logger)
 	if err != nil {
 		return IngressRouteReconciler{}, fmt.Errorf("failed to initialize integrations: %s", err)
 	}
@@ -68,7 +68,7 @@ func (r *IngressRouteReconciler) Reconcile(
 		Hosts: switchboard.NewHostCollection().
 			WithTLSHostsIfAvailable(ingressRoute.Spec.TLS).
 			WithRouteHostsIfRequired(ingressRoute.Spec.Routes).
-			Hosts(),
+			Hosts(ingressRoute.ObjectMeta.Annotations),
 		TLSSecretName: ext.AndThen(ingressRoute.Spec.TLS, func(tls traefik.TLS) string {
 			return tls.SecretName
 		}),

--- a/internal/controllers/utils.go
+++ b/internal/controllers/utils.go
@@ -17,7 +17,7 @@ import (
 )
 
 func integrationsFromConfig(
-	config configv1.Config, client client.Client,
+	config configv1.Config, client client.Client, logger *zap.Logger,
 ) ([]integrations.Integration, error) {
 	result := make([]integrations.Integration, 0)
 	externalDNS := config.Integrations.ExternalDNS
@@ -32,8 +32,8 @@ func integrationsFromConfig(
 				client, switchboard.NewServiceTarget(
 					externalDNS.TargetService.Name,
 					externalDNS.TargetService.Namespace,
-				),
-			))
+					logger,
+				)))
 		} else {
 			result = append(result, integrations.NewExternalDNS(
 				client, switchboard.NewStaticTarget(externalDNS.TargetIPs...),

--- a/internal/controllers/utils_test.go
+++ b/internal/controllers/utils_test.go
@@ -1,10 +1,12 @@
 package controllers
 
 import (
+	"context"
 	"testing"
 
 	configv1 "github.com/borchero/switchboard/internal/config/v1"
 	"github.com/borchero/switchboard/internal/k8tests"
+	"github.com/borchero/zeus/pkg/zeus"
 	certmanager "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"github.com/stretchr/testify/assert"
@@ -18,14 +20,14 @@ func TestIntegrationsFromConfig(t *testing.T) {
 
 	// Test all configurations of integrations
 	config := configv1.Config{}
-	integrations, err := integrationsFromConfig(config, client)
+	integrations, err := integrationsFromConfig(config, client, zeus.Logger(context.Background()))
 	require.Nil(t, err)
 	assert.Len(t, integrations, 0)
 
 	config.Integrations.ExternalDNS = &configv1.ExternalDNSIntegrationConfig{
 		TargetService: &configv1.ServiceRef{Name: "my-service", Namespace: "my-namespace"},
 	}
-	integrations, err = integrationsFromConfig(config, client)
+	integrations, err = integrationsFromConfig(config, client, zeus.Logger(context.Background()))
 	require.Nil(t, err)
 	assert.Len(t, integrations, 1)
 	assert.Equal(t, "external-dns", integrations[0].Name())
@@ -41,7 +43,7 @@ func TestIntegrationsFromConfig(t *testing.T) {
 			},
 		},
 	}
-	integrations, err = integrationsFromConfig(config, client)
+	integrations, err = integrationsFromConfig(config, client, zeus.Logger(context.Background()))
 	require.Nil(t, err)
 	assert.Len(t, integrations, 1)
 	assert.Equal(t, "cert-manager", integrations[0].Name())
@@ -49,18 +51,18 @@ func TestIntegrationsFromConfig(t *testing.T) {
 	config.Integrations.ExternalDNS = &configv1.ExternalDNSIntegrationConfig{
 		TargetIPs: []string{"127.0.0.1"},
 	}
-	integrations, err = integrationsFromConfig(config, client)
+	integrations, err = integrationsFromConfig(config, client, zeus.Logger(context.Background()))
 	require.Nil(t, err)
 	assert.Len(t, integrations, 2)
 
 	// Must fail if external DNS is not configured correctly
 	config.Integrations.ExternalDNS = &configv1.ExternalDNSIntegrationConfig{}
-	_, err = integrationsFromConfig(config, client)
+	_, err = integrationsFromConfig(config, client, zeus.Logger(context.Background()))
 	require.NotNil(t, err)
 
 	config.Integrations.ExternalDNS = &configv1.ExternalDNSIntegrationConfig{
 		TargetIPs: []string{},
 	}
-	_, err = integrationsFromConfig(config, client)
+	_, err = integrationsFromConfig(config, client, zeus.Logger(context.Background()))
 	require.NotNil(t, err)
 }

--- a/internal/integrations/certmanager.go
+++ b/internal/integrations/certmanager.go
@@ -41,7 +41,7 @@ func (c *certManager) UpdateResource(
 ) error {
 	// If the ingress does not specify a TLS secret name or specifies no hosts, no certificate
 	// needs to be created.
-	if info.TLSSecretName == nil || len(info.Hosts) == 0 {
+	if info.TLSSecretName == nil || len(info.Hosts.Names) == 0 {
 		certificate := certmanager.Certificate{ObjectMeta: c.objectMeta(owner)}
 		if err := k8s.DeleteIfFound(ctx, c.client, &certificate); err != nil {
 			return fmt.Errorf("failed to delete TLS certificate: %w", err)
@@ -62,7 +62,7 @@ func (c *certManager) UpdateResource(
 		// Spec
 		template := c.template.Spec.DeepCopy()
 		template.SecretName = *info.TLSSecretName
-		template.DNSNames = info.Hosts
+		template.DNSNames = info.Hosts.Names
 		if err := mergo.Merge(&resource.Spec, template, mergo.WithOverride); err != nil {
 			return fmt.Errorf("failed to reconcile specification: %s", err)
 		}

--- a/internal/integrations/externaldns.go
+++ b/internal/integrations/externaldns.go
@@ -52,7 +52,7 @@ func (e *externalDNS) UpdateResource(
 ) error {
 	// If the ingress specifies no hosts, there should be no endpoint. We try deleting it and
 	// ignore any error if it was not found.
-	if len(info.Hosts) == 0 {
+	if len(info.Hosts.Names) == 0 {
 		dnsEndpoint := endpoint.DNSEndpoint{ObjectMeta: e.objectMeta(owner)}
 		if err := k8s.DeleteIfFound(ctx, e.client, &dnsEndpoint); err != nil {
 			return fmt.Errorf("failed to delete DNS endpoint: %w", err)
@@ -61,7 +61,7 @@ func (e *externalDNS) UpdateResource(
 	}
 
 	// Get the IPs of the target service
-	targets, err := e.target.Targets(ctx, e.client)
+	targets, err := e.target.Targets(ctx, e.client, info.Hosts.Target)
 	if err != nil {
 		return fmt.Errorf("failed to query IP for DNS A record: %w", err)
 	}
@@ -75,7 +75,7 @@ func (e *externalDNS) UpdateResource(
 		}
 
 		// Spec
-		resource.Spec.Endpoints = e.endpoints(info.Hosts, targets)
+		resource.Spec.Endpoints = e.endpoints(info.Hosts.Names, targets)
 		return nil
 	}); err != nil {
 		return fmt.Errorf("failed to upsert DNS endpoint: %w", err)

--- a/internal/integrations/interface.go
+++ b/internal/integrations/interface.go
@@ -5,6 +5,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/borchero/switchboard/internal/switchboard"
 )
 
 const (
@@ -14,7 +16,7 @@ const (
 
 // IngressInfo encapsulates information extracted from ingress objects that integrations act upon.
 type IngressInfo struct {
-	Hosts         []string
+	Hosts         switchboard.HostsTarget
 	TLSSecretName *string
 }
 

--- a/internal/switchboard/targets.go
+++ b/internal/switchboard/targets.go
@@ -3,17 +3,23 @@ package switchboard
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"sort"
+	"strings"
 
+	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/mabels/ipaddress/go/ipaddress"
 )
 
 // Target is a type which allows to retrieve a potentially dynamically changing IP from Kubernetes.
 type Target interface {
 	// Targets returns the IPv4/IPv6 addresses or hostnames that should be used as targets or an
 	// error if the addresses/hostnames cannot be retrieved.
-	Targets(ctx context.Context, client client.Client) ([]string, error)
+	Targets(ctx context.Context, client client.Client, target *string) ([]string, error)
 	// NamespacedName returns the namespaced name of the dynamic target service or none if the IP
 	// is not retrieved dynamically.
 	NamespacedName() *types.NamespacedName
@@ -24,24 +30,85 @@ type Target interface {
 //-------------------------------------------------------------------------------------------------
 
 type serviceTarget struct {
-	name types.NamespacedName
+	name   types.NamespacedName
+	logger *zap.Logger
 }
 
 // NewServiceTarget creates a new target which dynamically sources the IP from the provided
 // Kubernetes service.
-func NewServiceTarget(name, namespace string) Target {
+func NewServiceTarget(name, namespace string, log *zap.Logger) Target {
 	return serviceTarget{
-		name: types.NamespacedName{Name: name, Namespace: namespace},
+		logger: log,
+		name:   types.NamespacedName{Name: name, Namespace: namespace},
 	}
 }
 
-func (t serviceTarget) Targets(ctx context.Context, client client.Client) ([]string, error) {
+func (t serviceTarget) Targets(ctx context.Context, client client.Client, targets *string) ([]string, error) {
 	// Get service
-	var service v1.Service
-	if err := client.Get(ctx, t.name, &service); err != nil {
-		return nil, fmt.Errorf("failed to query service: %w", err)
+	if targets == nil {
+		tmp := fmt.Sprintf("%s/%s", t.name.Namespace, t.name.Name)
+		targets = &tmp
 	}
-	return t.targetsFromService(service), nil
+	out := []string{}
+	for _, target := range strings.Split(*targets, ",") {
+		target = strings.TrimSpace(target)
+		if len(target) == 0 {
+			continue
+		}
+		if ipaddress.Parse(target).IsOk() {
+			t.logger.Debug(fmt.Sprintf("TargetIP:%s", target))
+			out = append(out, target)
+			continue
+		}
+		// very bad regex
+		if found, _ := regexp.MatchString("[0-9a-zA-Z\\-]+\\.[0-9a-zA-Z\\-]+.*", target); found {
+			t.logger.Debug(fmt.Sprintf("TargetCNAME:%s", target))
+			out = append(out, target)
+			continue
+		}
+		parts := strings.Split(target, "/")
+		nsName := types.NamespacedName{
+			Namespace: t.name.Namespace,
+			Name:      parts[0],
+		}
+		if len(parts) > 1 {
+			nsName.Namespace = parts[0]
+			nsName.Name = parts[1]
+		}
+		var service v1.Service
+		if err := client.Get(ctx, nsName, &service); err != nil {
+			return nil, fmt.Errorf("failed to query service: %s:%s:%w", nsName.Namespace, nsName.Name, err)
+		}
+		t.logger.Debug(fmt.Sprintf("TargetFromService:%s/%s - %s", nsName.Namespace, nsName.Name, target))
+		targets := t.targetsFromService(service)
+		out = append(out, targets...)
+	}
+	reduce := map[string]string{}
+	for _, target := range out {
+		class := "CNAME"
+		if ipaddress.Parse(target).IsOk() {
+			class = "IP"
+		}
+		reduce[target] = class
+	}
+	var itsCnameOrIp string
+	countClass := 0
+	out = []string{}
+	for target, class := range reduce {
+		out = append(out, target)
+		countClass++
+		if itsCnameOrIp == "" {
+			itsCnameOrIp = class
+		}
+		if itsCnameOrIp != class {
+			return nil, fmt.Errorf("cannot mix CNAME and IP addresses in target: %s", target)
+		}
+		if itsCnameOrIp == "CNAME" && countClass > 1 {
+			return nil, fmt.Errorf("CNAME allows only one target: %s", target)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
 }
 
 func (t serviceTarget) targetsFromService(service v1.Service) []string {
@@ -80,10 +147,10 @@ type staticTarget struct {
 // NewStaticTarget creates a new target which provides the given static IPs. IPs may be IPv4 or
 // IPv6 addresses (and any combination thereof).
 func NewStaticTarget(ips ...string) Target {
-	return staticTarget{ips}
+	return staticTarget{ips: ips}
 }
 
-func (t staticTarget) Targets(ctx context.Context, client client.Client) ([]string, error) {
+func (t staticTarget) Targets(ctx context.Context, client client.Client, targets *string) ([]string, error) {
 	return t.ips, nil
 }
 

--- a/internal/switchboard/targets_test.go
+++ b/internal/switchboard/targets_test.go
@@ -2,10 +2,12 @@ package switchboard
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/borchero/switchboard/internal/k8tests"
+	"github.com/borchero/zeus/pkg/zeus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
@@ -26,8 +28,8 @@ func TestServiceTargetTargets(t *testing.T) {
 	require.Nil(t, err)
 
 	// Check whether we find the cluster IP
-	target := NewServiceTarget(service.Name, service.Namespace)
-	targets, err := target.Targets(ctx, ctrlClient)
+	target := NewServiceTarget(service.Name, service.Namespace, zeus.Logger(ctx))
+	targets, err := target.Targets(ctx, ctrlClient, nil)
 	require.Nil(t, err)
 	assert.ElementsMatch(t, service.Spec.ClusterIPs, targets)
 
@@ -37,13 +39,51 @@ func TestServiceTargetTargets(t *testing.T) {
 	require.Nil(t, err)
 
 	// Check whether we find the load balancer IP
-	time.Sleep(time.Second)
-	name := client.ObjectKeyFromObject(&service)
-	err = ctrlClient.Get(ctx, name, &service)
+	for i := 0; i < 15 && len(service.Status.LoadBalancer.Ingress) == 0; i++ {
+		time.Sleep(time.Second) // Wait for service to be ready
+		// time.Sleep(time.Second)
+		name := client.ObjectKeyFromObject(&service)
+		err = ctrlClient.Get(ctx, name, &service)
+		require.Nil(t, err)
+	}
+
+	targets, err = target.Targets(ctx, ctrlClient, nil)
 	require.Nil(t, err)
-	targets, err = target.Targets(ctx, ctrlClient)
+	var external string
+	if len(service.Status.LoadBalancer.Ingress[0].IP) > 0 {
+		external = service.Status.LoadBalancer.Ingress[0].IP
+	}
+	if len(service.Status.LoadBalancer.Ingress[0].Hostname) > 0 {
+		external = service.Status.LoadBalancer.Ingress[0].Hostname
+	}
+	assert.ElementsMatch(t, []string{external}, targets)
+
+	explictTarget := fmt.Sprintf("1.1.1.1, 1::1 , www.test.bla, %s/my-service, my-service, 2.2.2.2, 2::2 , www.test.blub,  ,", namespace)
+	_, err = target.Targets(ctx, ctrlClient, &explictTarget)
+	require.NotNil(t, err)
+
+	explictTarget = fmt.Sprintf("www.test.bla, %s/my-service, my-service,  ", namespace)
+	_, err = target.Targets(ctx, ctrlClient, &explictTarget)
+	require.NotNil(t, err)
+
+	explictTarget = fmt.Sprintf("1.1.1.1, 1::1, %s/my-service, my-service,  ", namespace)
+	_, err = target.Targets(ctx, ctrlClient, &explictTarget)
+	require.NotNil(t, err)
+
+	explictTarget = fmt.Sprintf("%s/my-service, my-service,  ", namespace)
+	ips, err := target.Targets(ctx, ctrlClient, &explictTarget)
 	require.Nil(t, err)
-	assert.ElementsMatch(t, []string{service.Status.LoadBalancer.Ingress[0].IP}, targets)
+	assert.ElementsMatch(t, ips, []string{external})
+
+	explictTarget = "www.test.bla,  "
+	ips, err = target.Targets(ctx, ctrlClient, &explictTarget)
+	require.Nil(t, err)
+	assert.ElementsMatch(t, ips, []string{"www.test.bla"})
+
+	explictTarget = "2::2, 1.1.1.1, 1.1.1.1, 1::1, 1::1, "
+	ips, err = target.Targets(ctx, ctrlClient, &explictTarget)
+	require.Nil(t, err)
+	assert.ElementsMatch(t, ips, []string{"1.1.1.1", "1::1", "2::2"})
 }
 
 func TestServiceTargetTargetsFromService(t *testing.T) {
@@ -91,10 +131,11 @@ func TestServiceTargetTargetsFromService(t *testing.T) {
 	}}
 	targets = target.targetsFromService(service)
 	assert.ElementsMatch(t, []string{"example.lb.identifier.amazonaws.com"}, targets)
+
 }
 
 func TestServiceTargetNamespacedName(t *testing.T) {
-	target := NewServiceTarget("my-service", "my-namespace")
+	target := NewServiceTarget("my-service", "my-namespace", zeus.Logger(context.Background()))
 	name := target.NamespacedName()
 	assert.Equal(t, "my-service", name.Name)
 	assert.Equal(t, "my-namespace", name.Namespace)
@@ -104,7 +145,7 @@ func TestStaticTargetIPs(t *testing.T) {
 	ctx := context.Background()
 	expectedIPs := []string{"127.0.0.1", "2001:db8::1"}
 	target := NewStaticTarget(expectedIPs...)
-	ips, err := target.Targets(ctx, nil)
+	ips, err := target.Targets(ctx, nil, nil)
 	require.Nil(t, err)
 	assert.ElementsMatch(t, expectedIPs, ips)
 }


### PR DESCRIPTION
Added the a annotation to ingressroute to enable a dynamic target lookup

  switchboard.borchero.com/target

 1. a comma seperated list of ip number ipv4 ipv6 [1.1.1.1,1::1]
 2. one domain name [cname.example.cname]
 3. service key like k8snamespace/svcname or svcname than the
     integrations.externalDNS.targetService.namespace is used