### PR TITLE
Helm chart: Allow to use imagePullSecrets for container

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -57,6 +57,7 @@ The following lists all values that may be set when installing this chart (see
 | external-dns.sources[2] | string | `"ingress"` |  |
 | image.name | string | `"ghcr.io/borchero/switchboard"` | The switchboard image to use. |
 | image.tag | string | `nil` | The switchboard image tag to use. If not provided, assumes the same version as the chart. |
+| image.pullSecrets | list | `nil` | Optional list of existing secrets containing credentials for private container registry. |
 | integrations.certManager.certificateTemplate | object | `{}` | The certificate template to use when creating certificates via the cert-manager    integration. Unless `certificateIssuer.create` is set to `true` when installing this    chart, setting `.spec.IssuerRef` is required. |
 | integrations.certManager.enabled | bool | `false` | Whether the cert-manager integration should be enabled. If enabled, `Certificate`    resources are created by Switchboard. Setting this to `true` requires specifying an issuer    via `integrations.certManager.issuer` or letting the chart create its own issuer by    setting `certificateIssuer.create = true` and specifying additional properties for the    certificate issuer. |
 | integrations.externalDNS.enabled | bool | `false` | Whether the external-dns integration should be enabled. If enabled `DNSEndpoint` resources    are created by Switchboard. Setting this to `true` requires specifying the target via    `integrations.externalDNS.target`. |

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -22,6 +22,12 @@ spec:
         {{ toYaml .Values.podAnnotations | nindent 8 }}
     spec:
       serviceAccountName: {{ .Release.Name }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       containers:
         - name: switchboard
           image: {{ .Values.image.name }}:{{ include "image.tag" . }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -3,6 +3,10 @@ image:
   name: ghcr.io/borchero/switchboard
   # -- The switchboard image tag to use. If not provided, assumes the same version as the chart.
   tag: ~
+  # -- Optionally specify an array of imagePullSecrets to use when pulling from a private
+  #    container registry. Secrets must be manually created in the namespace.
+  # pullSecrets:
+  #   - "myExistingSecret"
 
 # -- The number of manager replicas to use.
 replicas: 1


### PR DESCRIPTION
<!-- Please provide an expressive pull request title as it will be listed in the release notes. -->

## Motivation

<!-- What is the motivation behind this pull request? -->

The Switchboard container image currently cannot be pulled from private registries requiring authentication.

<!-- If there exists an issue that is resolved with this pull request, please link it here. If the
motivation is already lined out in the issue, linking the issue suffices. -->

fixes #31 

## Explanation

<!-- How does this pull request attempt to solve the issue outlined in the motivation? -->

This pull request adds the option to define `image.pullSecrets` list value for the helm chart, which allows using an existing secret to access private registry. 

## Changes

<!-- Please list a summary of your changes. -->

- added image.pullSecrets chart value
- if this value is defined, contents are inserted in the Deployment spec.

## Checklist

<!-- Please make sure that you took care of the following: -->

- [X] I have updated the documentation if necessary

As this does not impact the original chart if the value is not defined, I think additional tests are not needed.
