### PR TITLE
Removed the indentation of solvers variable

### DIFF
--- a/chart/templates/issuer.yaml
+++ b/chart/templates/issuer.yaml
@@ -10,5 +10,5 @@ spec:
     privateKeySecretRef:
       name: {{ .Release.Name }}-letsencrypt-issuer
     solvers:
-      {{ toYaml .Values.certificateIssuer.solvers | indent 6 }}
+{{ toYaml .Values.certificateIssuer.solvers | indent 6 }}
 {{ end }}

--- a/chart/templates/issuer.yaml
+++ b/chart/templates/issuer.yaml
@@ -10,5 +10,5 @@ spec:
     privateKeySecretRef:
       name: {{ .Release.Name }}-letsencrypt-issuer
     solvers:
-{{ toYaml .Values.certificateIssuer.solvers | indent 6 }}
+      {{ toYaml .Values.certificateIssuer.solvers | nindent 6 }}
 {{ end }}


### PR DESCRIPTION
The indentation has been removed from the start of the line where the `.Values.certificateIssuer.solvers` were being specified.

## Motivation

When trying to include solvers in the values to allow the CloudDNS to be used, it kept failing to install/upgrade the helm chart deployed using the specification on the Cert-Manager docs regarding the solver for [CloudDNS](https://cert-manager.io/docs/configuration/acme/dns01/google/#create-an-issuer-that-uses-clouddns). The error being received was:

```
Error: UPGRADE FAILED: YAML parse error on switchboard/templates/issuer.yaml: error converting YAML to JSON: yaml: line 12: did not find expected '-' indicator
```

The values being defined in the `values.yaml` (sanitised):

```
...
certificateIssuer:
  create: true
  email: <EMAIL>
  solvers:
  - dns01:
      cloudDNS:
        project: <PROJECT_ID>
        serviceAccountSecretRef:
          name: <secretRef>
          key: <secretKey>
...
```

After removing the lines after pulling down the chart and testing locally, the chart is being deployed fine with the same values.

```
Release "switchboard" has been upgraded. Happy Helming!
NAME: switchboard
LAST DEPLOYED: Tue Dec 20 15:13:17 2022
NAMESPACE: switchboard
STATUS: deployed
REVISION: 5
TEST SUITE: None
```

## Explanation

After trial and error, removing this whitespace, while keeping the same specification in the values.yaml, allowed the chart to be deployed.

## Changes

Removed the 6 indents at the beginning of the line.

## Checklist

- [x] I added relevant tests
- [x] I have updated the documentation if necessary
