### PR TITLE
Copy annotations from IngressRoute to DNSEndpoint

### DIFF
--- a/internal/integrations/externaldns.go
+++ b/internal/integrations/externaldns.go
@@ -89,8 +89,9 @@ func (e *externalDNS) UpdateResource(
 
 func (e *externalDNS) objectMeta(owner metav1.Object) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
-		Name:      owner.GetName(),
-		Namespace: owner.GetNamespace(),
+		Name:        owner.GetName(),
+		Namespace:   owner.GetNamespace(),
+		Annotations: owner.GetAnnotations(),
 	}
 }
 


### PR DESCRIPTION
## Motivation

External DNS has a Cloudflare provider and when using it you can add `external-dns.alpha.kubernetes.io/cloudflare-proxied` to the `DNSEndpoint` to have it create the DNS record non-proxied (or proxied if you have it globally default to no proxy), and Switchboard doesn't copy the annotations down to the created resource.

## Explanation

This PR puts the annotations from the `IngressRoute` on the created `DNSEndpoint` resource, might be worth it in the future to have a list of annotations to copy instead of all of them.

## Changes

Added the `Annotations` field to the struct returned from the `objectMeta` method in the externaldns integration.
