### PR TITLE
Fix loading configuration from YAML

### DIFF
--- a/chart/templates/_config.tpl
+++ b/chart/templates/_config.tpl
@@ -1,7 +1,5 @@
 {{ define "config" }}
 {{- $cfg := .Values.config -}}
-apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
-kind: ControllerManagerConfig
 health:
   healthProbeBindAddress: :8081
 leaderElection:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -40,7 +40,7 @@ func main() {
 		if err != nil {
 			logger.Fatal("failed to open config file", zap.Error(err))
 		}
-		if err := yaml.NewDecoder(file).Decode(config); err != nil {
+		if err := yaml.NewDecoder(file).Decode(&config); err != nil {
 			logger.Fatal("failed to parse config file", zap.Error(err))
 		}
 	}

--- a/dev/config.yaml
+++ b/dev/config.yaml
@@ -1,5 +1,3 @@
-apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
-kind: ControllerManagerConfig
 health:
   healthProbeBindAddress: :8081
 leaderElection:

--- a/internal/config/v1/config.go
+++ b/internal/config/v1/config.go
@@ -6,70 +6,70 @@ import (
 
 // Config is the Schema for the configs API
 type Config struct {
-	ControllerConfig `json:",inline"`
-	Selector         IngressSelector    `json:"selector"`
-	Integrations     IntegrationConfigs `json:"integrations"`
+	ControllerConfig `yaml:",inline"`
+	Selector         IngressSelector    `yaml:"selector"`
+	Integrations     IntegrationConfigs `yaml:"integrations"`
 }
 
 //-------------------------------------------------------------------------------------------------
 
 // ControllerConfig provides configuration for the controller.
 type ControllerConfig struct {
-	Health         HealthConfig         `json:"health,omitempty"`
-	LeaderElection LeaderElectionConfig `json:"leaderElection,omitempty"`
-	Metrics        MetricsConfig        `json:"metrics,omitempty"`
+	Health         HealthConfig         `yaml:"health,omitempty"`
+	LeaderElection LeaderElectionConfig `yaml:"leaderElection,omitempty"`
+	Metrics        MetricsConfig        `yaml:"metrics,omitempty"`
 }
 
 // HealthConfig provides configuration for the controller health checks.
 type HealthConfig struct {
-	HealthProbeBindAddress string `json:"healthProbeBindAddress,omitempty"`
+	HealthProbeBindAddress string `yaml:"healthProbeBindAddress,omitempty"`
 }
 
 // LeaderElectionConfig provides configuration for the leader election.
 type LeaderElectionConfig struct {
-	LeaderElect       bool   `json:"leaderElect,omitempty"`
-	ResourceName      string `json:"resourceName,omitempty"`
-	ResourceNamespace string `json:"resourceNamespace,omitempty"`
+	LeaderElect       bool   `yaml:"leaderElect,omitempty"`
+	ResourceName      string `yaml:"resourceName,omitempty"`
+	ResourceNamespace string `yaml:"resourceNamespace,omitempty"`
 }
 
 // MetricsConfig provides configuration for the controller metrics.
 type MetricsConfig struct {
-	BindAddress string `json:"bindAddress,omitempty"`
+	BindAddress string `yaml:"bindAddress,omitempty"`
 }
 
 //-------------------------------------------------------------------------------------------------
 
 // IngressSelector can be used to limit operations to ingresses with a specific class.
 type IngressSelector struct {
-	IngressClass *string `json:"ingressClass,omitempty"`
+	IngressClass *string `yaml:"ingressClass,omitempty"`
 }
 
 // IntegrationConfigs describes the configurations for all integrations.
 type IntegrationConfigs struct {
-	ExternalDNS *ExternalDNSIntegrationConfig `json:"externalDNS"`
-	CertManager *CertManagerIntegrationConfig `json:"certManager"`
+	ExternalDNS *ExternalDNSIntegrationConfig `yaml:"externalDNS"`
+	CertManager *CertManagerIntegrationConfig `yaml:"certManager"`
 }
 
 // ExternalDNSIntegrationConfig describes the configuration for the external-dns integration.
 // Exactly one of target and target IPs should be set.
 type ExternalDNSIntegrationConfig struct {
-	TargetService *ServiceRef `json:"targetService,omitempty"`
-	TargetIPs     []string    `json:"targetIPs,omitempty"`
+	TargetService *ServiceRef `yaml:"targetService,omitempty"`
+	TargetIPs     []string    `yaml:"targetIPs,omitempty"`
 }
 
 // CertManagerIntegrationConfig describes the configuration for the cert-manager integration.
 type CertManagerIntegrationConfig struct {
-	Template v1.Certificate `json:"certificateTemplate"`
+	Template v1.Certificate `yaml:"certificateTemplate"`
 }
 
 // ServiceRef uniquely describes a Kubernetes service.
 type ServiceRef struct {
-	Name      string `json:"name"`
-	Namespace string `json:"namespace"`
+	Name      string `yaml:"name"`
+	Namespace string `yaml:"namespace"`
 }
 
 // IssuerRef uniquely references a cert-manager issuer.
 type IssuerRef struct {
-	Kind string `json:"kind"`
-	Name string `json:"name"`
+	Kind string `yaml:"kind"`
+	Name string `yaml:"name"`
 }


### PR DESCRIPTION
<!-- Please provide an expressive pull request title as it will be listed in the release notes. -->

## Motivation

Fixes #76. Unfortunately, upgrading the controller runtime which required manual config parsing, resulted in not reading the YAML config correctly. This caused the port for the health endpoints to not be set, thus, causing all health probes to fail.

I don't know why the tests didn't catch this, I think they need some overhaul...

## Checklist

<!-- Please make sure that you took care of the following: -->

- [x] I added relevant tests
- [x] I have updated the documentation if necessary
