### PR TITLE
feat: Add support for hostname annotation

### DIFF
--- a/internal/switchboard/targets_test.go
+++ b/internal/switchboard/targets_test.go
@@ -92,6 +92,31 @@ func TestServiceTargetTargetsFromService(t *testing.T) {
 	}}
 	targets = target.targetsFromService(service)
 	assert.ElementsMatch(t, []string{"example.lb.identifier.amazonaws.com"}, targets)
+
+	// Source hostname from annotation
+	service.SetAnnotations(map[string]string{
+		HostnameKey: "example.identifier.amazonaws.com",
+	})
+	targets = target.targetsFromService(service)
+	assert.ElementsMatch(t, []string{"example.identifier.amazonaws.com"}, targets)
+
+	// Ensure annotation takes precedence
+	service.SetAnnotations(map[string]string{
+		HostnameKey: "example.identifier.amazonaws.com",
+	})
+	service.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{
+		IP:       "192.168.5.5",
+		Hostname: "example.lb.identifier.amazonaws.com",
+	}}
+	targets = target.targetsFromService(service)
+	assert.ElementsMatch(t, []string{"example.identifier.amazonaws.com"}, targets)
+
+	// Ensure only one hostname
+	service.SetAnnotations(map[string]string{
+		HostnameKey: "example.identifier.amazonaws.com, example2.identifier.amazonaws.com",
+	})
+	targets = target.targetsFromService(service)
+	assert.ElementsMatch(t, []string{"example.identifier.amazonaws.com"}, targets)
 }
 
 func TestServiceTargetNamespacedName(t *testing.T) {


### PR DESCRIPTION
# Motivation

At present, `external-dns` is relying on `status.loadBalancer.ingress` or the `ClusterIP` for targets. This becomes an issue when attempting to use CNAME records that the K8s cluster is not aware of.

By using `external-dns.alpha.kubernetes.io/hostname` as documented [here](https://kubernetes-sigs.github.io/external-dns/latest/docs/annotations/annotations/), we can force the endpoint target created through `switchboard` to that of the annotation applied to the `targetService` specified in the helm chart.

Resolves https://github.com/borchero/switchboard/issues/36.

# Changes

Prioritize the `external-dns.alpha.kubernetes.io/hostname` annotation when selecting endpoint targets for `external-dns` resources.
